### PR TITLE
Add the ability to ignore certain events

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -22,6 +22,7 @@ module.exports.watch = function (region) {
 
   var ignored_users =  process.env.IGNORED_USERNAMES ? process.env.IGNORED_USERNAMES.split(',') : [];
   var ignored_ua =  process.env.IGNORED_UA ? process.env.IGNORED_UA.split(',') : [];
+  var ignored_events = process.env.IGNORED_EVENTS ? process.env.IGNORED_EVENTS.split(',') : [];
 
   function find_events (params) {
     log('query with', params);
@@ -41,7 +42,8 @@ module.exports.watch = function (region) {
       }).filter(function (event) {
         return !sent.get(event.EventId) &&
                !~ignored_users.indexOf(event.Username) &&
-               !~ignored_ua.indexOf(event.CloudTrailEvent.userAgent);
+               !~ignored_ua.indexOf(event.CloudTrailEvent.userAgent) &&
+               !~ignored_events.indexOf(event.EventName);
       });
 
       events = _.sortBy(events, 'EventTime');


### PR DESCRIPTION
Now that AWS has added List and Describe events, it'd be good to be able to ignore them (or to ignore specific events).

This extends the existing ignore options to add EventName as something that can be ignored.